### PR TITLE
feature/RedesignBeans

### DIFF
--- a/src/main/java/com/volasoftware/tinder/controllers/AuthenticationController.java
+++ b/src/main/java/com/volasoftware/tinder/controllers/AuthenticationController.java
@@ -7,6 +7,7 @@ import com.volasoftware.tinder.dtos.LoginRequest;
 import com.volasoftware.tinder.dtos.RegisterRequest;
 import com.volasoftware.tinder.responses.ResponseHandler;
 import com.volasoftware.tinder.services.contracts.AuthenticationService;
+import com.volasoftware.tinder.services.contracts.AccountService;
 import java.security.Principal;
 import javax.validation.Valid;
 import io.swagger.annotations.Api;
@@ -26,6 +27,8 @@ import org.springframework.web.bind.annotation.*;
 public class AuthenticationController {
 
     private final AuthenticationService authenticationService;
+
+    private final AccountService accountService;
 
     @ApiOperation(value = "Register new account")
     @ApiResponses(
@@ -86,7 +89,7 @@ public class AuthenticationController {
         return ResponseHandler.generateResponse(
             AccountConstant.DETAILS,
             HttpStatus.OK,
-            authenticationService.getAccountByEmail(principal.getName()));
+            accountService.getAccountDtoByEmail(principal.getName()));
     }
 
     @ApiOperation(value = "Update Profile of logged Account")

--- a/src/main/java/com/volasoftware/tinder/services/contracts/AccountService.java
+++ b/src/main/java/com/volasoftware/tinder/services/contracts/AccountService.java
@@ -1,0 +1,30 @@
+package com.volasoftware.tinder.services.contracts;
+
+import com.volasoftware.tinder.constants.AccountType;
+import com.volasoftware.tinder.dtos.AccountDto;
+import com.volasoftware.tinder.models.Account;
+import java.util.List;
+import java.util.Set;
+import org.springframework.data.domain.Pageable;
+
+public interface AccountService {
+
+    List<AccountDto> getAccounts(Pageable pageable);
+
+    AccountDto getAccountDtoByEmail(String email);
+
+    List<Account> getFriendsByLocation(Account loggedAccount, Double accountLatitude,
+        Double accountLongitude);
+
+    Account getAccountById(Long id);
+
+    Account getLoggedAccount();
+
+    Set<Account> getAccountsByType(AccountType accountType, Pageable pageable);
+
+    Account updateAccount(Account account);
+
+    void checkIfEmailIsTaken(String email);
+
+    Account getAccountByEmail(String email);
+}

--- a/src/main/java/com/volasoftware/tinder/services/contracts/AuthenticationService.java
+++ b/src/main/java/com/volasoftware/tinder/services/contracts/AuthenticationService.java
@@ -1,43 +1,23 @@
 package com.volasoftware.tinder.services.contracts;
 
-import com.volasoftware.tinder.constants.AccountType;
 import com.volasoftware.tinder.dtos.AccountDto;
 import com.volasoftware.tinder.dtos.EmailDto;
 import com.volasoftware.tinder.dtos.LoginRequest;
 import com.volasoftware.tinder.dtos.RegisterRequest;
-import com.volasoftware.tinder.models.Account;
 import com.volasoftware.tinder.responses.LoginResponse;
 
 import java.security.Principal;
-import java.util.List;
-import java.util.Set;
-import org.springframework.data.domain.Pageable;
 
 
 public interface AuthenticationService {
 
-    List<AccountDto> getAccounts(Pageable pageable);
-
-    List<Account> getFriendsByLocation(Account loggedAccount, Double accountLatitude,
-        Double accountLongitude);
-
-    Account getAccountById(Long id);
-
-    Account getLoggedAccount();
-
-    Set<Account> getAccountsByType(AccountType accountType, Pageable pageable);
-
     AccountDto register(RegisterRequest registerRequest);
-
-    AccountDto getAccountByEmail(String email);
 
     AccountDto verifyAccount(String token);
 
     LoginResponse login(LoginRequest loginRequest);
 
     AccountDto updateAccount(AccountDto accountDto, Principal principal);
-
-    Account updateAccount(Account account);
 
     AccountDto recoverPassword(Principal principal);
 

--- a/src/main/java/com/volasoftware/tinder/services/contracts/FriendService.java
+++ b/src/main/java/com/volasoftware/tinder/services/contracts/FriendService.java
@@ -4,6 +4,7 @@ import com.volasoftware.tinder.dtos.FriendDto;
 import com.volasoftware.tinder.dtos.FriendSearchDto;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 
 public interface FriendService {
 
@@ -16,4 +17,7 @@ public interface FriendService {
     String linkFriends(Long accountId, Pageable pageable);
 
     FriendDto getFriendInfo(Long accountId);
+
+    @Async
+    void executeAsyncLinkFriends(Long accountId);
 }

--- a/src/main/java/com/volasoftware/tinder/services/implementations/AccountServiceImpl.java
+++ b/src/main/java/com/volasoftware/tinder/services/implementations/AccountServiceImpl.java
@@ -1,0 +1,104 @@
+package com.volasoftware.tinder.services.implementations;
+
+import com.volasoftware.tinder.constants.AccountConstant;
+import com.volasoftware.tinder.constants.AccountType;
+import com.volasoftware.tinder.constants.MailConstant;
+import com.volasoftware.tinder.dtos.AccountDto;
+import com.volasoftware.tinder.exceptions.AccountNotFoundException;
+import com.volasoftware.tinder.exceptions.EmailIsTakenException;
+import com.volasoftware.tinder.mapper.AccountMapper;
+import com.volasoftware.tinder.models.Account;
+import com.volasoftware.tinder.repositories.AccountRepository;
+import com.volasoftware.tinder.services.contracts.AccountService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountServiceImpl implements AccountService {
+
+    private final AccountRepository accountRepository;
+
+    private final AccountMapper accountMapper;
+
+    @Override
+    public List<AccountDto> getAccounts(Pageable pageable) {
+        Page<Account> accountsPage = accountRepository.findAll(pageable);
+        List<Account> accountsList = new ArrayList<>();
+
+        while (!accountsPage.isEmpty()) {
+            accountsPage.forEach(accountsList::add);
+
+            accountsPage = accountRepository.findAll(pageable.next());
+        }
+
+        return accountMapper.accountListToAccountDtoList(accountsList);
+    }
+
+    @Override
+    public AccountDto getAccountDtoByEmail(String email) {
+        Account account = getAccountByEmail(email);
+        return accountMapper.accountToAccountDto(account);
+    }
+
+    @Override
+    public List<Account> getFriendsByLocation(Account loggedAccount, Double accountLatitude,
+        Double accountLongitude) {
+        return accountRepository.findFriendsByLocation(
+            loggedAccount.getId(), accountLatitude, accountLongitude);
+    }
+
+    @Override
+    public Account getAccountById(Long id) {
+        return accountRepository.findById(id).orElseThrow(
+            () -> new AccountNotFoundException(AccountConstant.NOT_FOUND)
+        );
+    }
+
+    @Override
+    public Account getLoggedAccount() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+
+        return getAccountByEmail(username);
+    }
+
+    @Override
+    public Set<Account> getAccountsByType(AccountType accountType, Pageable pageable) {
+
+        return Stream.iterate(pageable, Pageable::next)
+            .map(pageRequest -> accountRepository.findByAccountType(accountType, pageRequest))
+            .takeWhile(page -> page != null && page.hasContent())
+            .flatMap(page -> page.getContent().stream())
+            .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Account updateAccount(Account account) {
+        return accountRepository.save(account);
+    }
+
+    @Override
+    public void checkIfEmailIsTaken(String email) {
+        Optional<Account> optionalAccount = accountRepository.findOneByEmail(email);
+        if (optionalAccount.isPresent()) {
+            throw new EmailIsTakenException(MailConstant.ALREADY_TAKEN);
+        }
+    }
+
+    @Override
+    public Account getAccountByEmail(String email) {
+        return accountRepository.findOneByEmail(email)
+            .orElseThrow(() -> new AccountNotFoundException(AccountConstant.NOT_FOUND));
+    }
+}

--- a/src/main/java/com/volasoftware/tinder/services/implementations/AuthenticationServiceImpl.java
+++ b/src/main/java/com/volasoftware/tinder/services/implementations/AuthenticationServiceImpl.java
@@ -7,29 +7,18 @@ import com.volasoftware.tinder.dtos.LoginRequest;
 import com.volasoftware.tinder.exceptions.*;
 import com.volasoftware.tinder.models.Account;
 import com.volasoftware.tinder.models.VerificationToken;
-import com.volasoftware.tinder.repositories.AccountRepository;
 import com.volasoftware.tinder.dtos.RegisterRequest;
 import com.volasoftware.tinder.mapper.AccountMapper;
 import com.volasoftware.tinder.responses.LoginResponse;
 import com.volasoftware.tinder.services.contracts.*;
 
 import java.security.Principal;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -47,7 +36,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
     private final EmailValidator emailValidator;
 
-    private final AccountRepository accountRepository;
+    private final AccountService accountService;
 
     private final AccountMapper accountMapper;
 
@@ -62,61 +51,9 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     private String verifyUrl;
 
     @Override
-    public List<AccountDto> getAccounts(Pageable pageable) {
-        Page<Account> accountsPage = accountRepository.findAll(pageable);
-        List<Account> accountsList = new ArrayList<>();
-
-        while (!accountsPage.isEmpty()) {
-            accountsPage.forEach(accountsList::add);
-
-            accountsPage = accountRepository.findAll(pageable.next());
-        }
-
-        return accountMapper.accountListToAccountDtoList(accountsList);
-    }
-
-    @Override
-    public AccountDto getAccountByEmail(String email) {
-        Account account = findAccountByEmail(email);
-        return accountMapper.accountToAccountDto(account);
-    }
-
-    @Override
-    public List<Account> getFriendsByLocation(Account loggedAccount, Double accountLatitude,
-        Double accountLongitude) {
-        return accountRepository.findFriendsByLocation(
-            loggedAccount.getId(), accountLatitude, accountLongitude);
-    }
-
-    @Override
-    public Account getAccountById(Long id) {
-        return accountRepository.findById(id).orElseThrow(
-            () -> new AccountNotFoundException(AccountConstant.NOT_FOUND)
-        );
-    }
-
-    @Override
-    public Account getLoggedAccount() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String username = authentication.getName();
-
-        return findAccountByEmail(username);
-    }
-
-    @Override
-    public Set<Account> getAccountsByType(AccountType accountType, Pageable pageable) {
-
-        return Stream.iterate(pageable, Pageable::next)
-            .map(pageRequest -> accountRepository.findByAccountType(accountType, pageRequest))
-            .takeWhile(page -> page != null && page.hasContent())
-            .flatMap(page -> page.getContent().stream())
-            .collect(Collectors.toSet());
-    }
-
-    @Override
     public AccountDto register(RegisterRequest registerRequest) {
         checkIfEmailIsValid(registerRequest.getEmail());
-        checkIfEmailIsTaken(registerRequest.getEmail());
+        accountService.checkIfEmailIsTaken(registerRequest.getEmail());
 
         registerRequest.setPassword(passwordEncoder.encode(registerRequest.getPassword()));
         Account account = accountMapper.registerRequestToAccount(registerRequest);
@@ -124,7 +61,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         account.setRole(Role.USER);
         account.setLocked(false);
         account.setVerified(false);
-        Account savedAccount = updateAccount(account);
+        Account savedAccount = accountService.updateAccount(account);
 
         VerificationToken verificationToken = verificationTokenService.generateToken(savedAccount);
         sendVerificationMail(registerRequest.getEmail(), verificationToken.getToken());
@@ -136,7 +73,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     public AccountDto verifyAccount(String token) {
         Account account = verificationTokenService.verifyToken(token);
         account.setVerified(true);
-        Account updatedAccount = updateAccount(account);
+        Account updatedAccount = accountService.updateAccount(account);
 
         return accountMapper.accountToAccountDto(updatedAccount);
     }
@@ -150,7 +87,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             )
         );
 
-        Account account = findAccountByEmail(loginRequest.getEmail());
+        Account account = accountService.getAccountByEmail(loginRequest.getEmail());
 
         if (!account.isVerified()) {
             throw new AccountNotVerifiedException(AccountConstant.NOT_VERIFIED);
@@ -161,7 +98,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
     @Override
     public AccountDto updateAccount(AccountDto accountDto, Principal principal) {
-        Account account = findAccountByEmail(accountDto.getEmail());
+        Account account = accountService.getAccountByEmail(accountDto.getEmail());
         if (!account.getEmail().equals(principal.getName())) {
             throw new AccountNotOwnerException(AccountConstant.NOT_OWNER);
         }
@@ -171,17 +108,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         account.setEmail(accountDto.getEmail());
         account.setGender(accountDto.getGender());
 
-        return accountMapper.accountToAccountDto(updateAccount(account));
-    }
-
-    @Override
-    public Account updateAccount(Account account) {
-        return accountRepository.save(account);
+        return accountMapper.accountToAccountDto(accountService.updateAccount(account));
     }
 
     @Override
     public AccountDto recoverPassword(Principal principal) {
-        Account account = findAccountByEmail(principal.getName());
+        Account account = accountService.getAccountByEmail(principal.getName());
         String randomPassword = UUID.randomUUID().toString();
 
         try {
@@ -191,14 +123,14 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         }
 
         account.setPassword(passwordEncoder.encode(randomPassword));
-        Account savedAccount = updateAccount(account);
+        Account savedAccount = accountService.updateAccount(account);
 
         return accountMapper.accountToAccountDto(savedAccount);
     }
 
     @Override
     public EmailDto resendVerification(EmailDto emailDto) {
-        Account account = findAccountByEmail(emailDto.getEmail());
+        Account account = accountService.getAccountByEmail(emailDto.getEmail());
         if (account.isVerified()) {
             throw new EmailAlreadyVerifiedException(MailConstant.ALREADY_CONFIRMED);
         }
@@ -220,24 +152,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         emailService.send(receiver, content);
     }
 
-    private Account findAccountByEmail(String email) {
-        return accountRepository.findOneByEmail(email)
-            .orElseThrow(() -> new AccountNotFoundException(AccountConstant.NOT_FOUND));
-    }
-
     private void sendVerificationMail(String receiver, String token) {
         String link = baseUrl + verifyUrl + token;
         byte[] contentBytes = fileService.readHtml(FilePathConstant.VERIFICATION_EMAIL_HTML);
         String content = new String(contentBytes).replace(HtmlConstant.HREF, link);
 
         emailService.send(receiver, content);
-    }
-
-    private void checkIfEmailIsTaken(String email) {
-        Optional<Account> optionalAccount = accountRepository.findOneByEmail(email);
-        if (optionalAccount.isPresent()) {
-            throw new EmailIsTakenException(MailConstant.ALREADY_TAKEN);
-        }
     }
 
     private void checkIfEmailIsValid(String email) {

--- a/src/main/java/com/volasoftware/tinder/services/implementations/FriendServiceImpl.java
+++ b/src/main/java/com/volasoftware/tinder/services/implementations/FriendServiceImpl.java
@@ -10,7 +10,7 @@ import com.volasoftware.tinder.exceptions.FriendNotFoundException;
 import com.volasoftware.tinder.exceptions.NoRealAccountsException;
 import com.volasoftware.tinder.mapper.FriendMapper;
 import com.volasoftware.tinder.models.Account;
-import com.volasoftware.tinder.services.contracts.AuthenticationService;
+import com.volasoftware.tinder.services.contracts.AccountService;
 import com.volasoftware.tinder.services.contracts.FriendService;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,14 +19,20 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class FriendServiceImpl implements FriendService {
 
-    private final AuthenticationService authenticationService;
+    public static final int PAGE_NUMBER = 0;
+    public static final int PAGE_SIZE = 10;
+    public static final int THREAD_DELAY = 10000;
+
+    private final AccountService accountService;
 
     private final Random random;
 
@@ -34,8 +40,8 @@ public class FriendServiceImpl implements FriendService {
 
     @Override
     public void addFriend(Long friendId) {
-        Account loggedAccount = authenticationService.getLoggedAccount();
-        Account friendAccount = authenticationService.getAccountById(friendId);
+        Account loggedAccount = accountService.getLoggedAccount();
+        Account friendAccount = accountService.getAccountById(friendId);
 
         if (hasFriends(loggedAccount)) {
             if (friendExist(loggedAccount, friendAccount)) {
@@ -46,17 +52,17 @@ public class FriendServiceImpl implements FriendService {
         }
 
         loggedAccount.getFriends().add(friendAccount);
-        authenticationService.updateAccount(loggedAccount);
+        accountService.updateAccount(loggedAccount);
     }
 
     @Override
     public void removeFriend(Long friendId) {
-        Account loggedAccount = authenticationService.getLoggedAccount();
-        Account friendAccount = authenticationService.getAccountById(friendId);
+        Account loggedAccount = accountService.getLoggedAccount();
+        Account friendAccount = accountService.getAccountById(friendId);
 
         if (friendExist(loggedAccount, friendAccount)) {
             loggedAccount.getFriends().remove(friendAccount);
-            authenticationService.updateAccount(loggedAccount);
+            accountService.updateAccount(loggedAccount);
         } else {
             throw new FriendNotFoundException(AccountConstant.FRIEND_NOT_FOUND);
         }
@@ -66,9 +72,9 @@ public class FriendServiceImpl implements FriendService {
     public List<FriendDto> sortFriendsByLocation(FriendSearchDto friendSearchDto) {
         Double accountLatitude = friendSearchDto.getLatitude();
         Double accountLongitude = friendSearchDto.getLongitude();
-        Account loggedAccount = authenticationService.getLoggedAccount();
+        Account loggedAccount = accountService.getLoggedAccount();
 
-        List<Account> sortedFriends = authenticationService.getFriendsByLocation(loggedAccount,
+        List<Account> sortedFriends = accountService.getFriendsByLocation(loggedAccount,
             accountLatitude, accountLongitude);
         if (sortedFriends.isEmpty()) {
             return Collections.emptyList();
@@ -88,8 +94,8 @@ public class FriendServiceImpl implements FriendService {
 
     @Override
     public FriendDto getFriendInfo(Long accountId) {
-        Account loggedAccount = authenticationService.getLoggedAccount();
-        Account friendAccount = authenticationService.getAccountById(accountId);
+        Account loggedAccount = accountService.getLoggedAccount();
+        Account friendAccount = accountService.getAccountById(accountId);
         if (friendExist(loggedAccount, friendAccount)) {
             return friendMapper.accountToFriendDto(friendAccount);
         }
@@ -97,11 +103,27 @@ public class FriendServiceImpl implements FriendService {
         throw new FriendNotFoundException(AccountConstant.FRIEND_NOT_FOUND);
     }
 
+    @Async
+    @Override
+    public void executeAsyncLinkFriends(Long accountId) {
+        try {
+            Thread.sleep(THREAD_DELAY);
+            Pageable pageable = createPageRequest();
+            linkRequestedAccountWithBots(accountId, pageable);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private Pageable createPageRequest() {
+        return PageRequest.of(PAGE_NUMBER, PAGE_SIZE);
+    }
+
 
     private String linkRequestedAccountWithBots(Long accountId, Pageable pageable) {
-        Account realAccount = authenticationService.getAccountById(accountId);
+        Account realAccount = accountService.getAccountById(accountId);
 
-        Set<Account> botSet = authenticationService.getAccountsByType(AccountType.BOT,
+        Set<Account> botSet = accountService.getAccountsByType(AccountType.BOT,
             pageable);
 
         int initialFriendsCount = getFriendsCount(realAccount);
@@ -121,17 +143,17 @@ public class FriendServiceImpl implements FriendService {
 
 
     private String linkAllAccountsWithBots(Pageable pageable) {
-        Set<Account> realAccounts = authenticationService.getAccountsByType(AccountType.REAL,
+        Set<Account> realAccounts = accountService.getAccountsByType(AccountType.REAL,
             pageable);
         if (realAccounts.isEmpty()) {
             throw new NoRealAccountsException(AccountConstant.ACCOUNTS_NOT_EXIST);
         }
 
-        Set<Account> botSet = authenticationService.getAccountsByType(AccountType.BOT,
+        Set<Account> botSet = accountService.getAccountsByType(AccountType.BOT,
             pageable);
 
         int initialFriendsCount = getFriendsCount(realAccounts);
-        int finalFriendsCount = 0;
+        int finalFriendsCount = PAGE_NUMBER;
         for (Account realAccount : realAccounts) {
             if (!hasFriends(realAccount)) {
                 realAccount.setFriends(new HashSet<>());
@@ -149,7 +171,7 @@ public class FriendServiceImpl implements FriendService {
     }
 
     private int getFriendsCount(Account account) {
-        return account.getFriends() == null ? 0 : account.getFriends().size();
+        return account.getFriends() == null ? PAGE_NUMBER : account.getFriends().size();
     }
 
     private int getFriendsCount(Set<Account> realAccounts) {
@@ -161,10 +183,10 @@ public class FriendServiceImpl implements FriendService {
         int randomBotsCount = random.nextInt(botAccounts.size());
         List<Account> botAccountList = new ArrayList<>(botAccounts);
         botAccountList.removeIf(botFriends::contains);
-        botFriends.addAll(botAccountList.subList(0, randomBotsCount));
+        botFriends.addAll(botAccountList.subList(PAGE_NUMBER, randomBotsCount));
         account.setFriends(botFriends);
 
-        return authenticationService.updateAccount(account);
+        return accountService.updateAccount(account);
     }
 
     private boolean hasFriends(Account loggedAccount) {

--- a/src/main/java/com/volasoftware/tinder/services/implementations/RatingServiceImpl.java
+++ b/src/main/java/com/volasoftware/tinder/services/implementations/RatingServiceImpl.java
@@ -7,7 +7,7 @@ import com.volasoftware.tinder.exceptions.RatingNotValidException;
 import com.volasoftware.tinder.models.Rating;
 import com.volasoftware.tinder.repositories.RatingRepository;
 import com.volasoftware.tinder.dtos.RatingResponseDto;
-import com.volasoftware.tinder.services.contracts.AuthenticationService;
+import com.volasoftware.tinder.services.contracts.AccountService;
 import com.volasoftware.tinder.services.contracts.FriendService;
 import com.volasoftware.tinder.services.contracts.RatingService;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ public class RatingServiceImpl implements RatingService {
 
     private final FriendService friendService;
 
-    private final AuthenticationService authenticationService;
+    private final AccountService accountService;
 
     @Override
     public RatingResponseDto rateFriend(RatingDto ratingDto) {
@@ -44,8 +44,8 @@ public class RatingServiceImpl implements RatingService {
 
     private Rating getNewRating(RatingDto ratingDto) {
         Rating rating = new Rating();
-        rating.setAccount(authenticationService.getLoggedAccount());
-        rating.setFriend(authenticationService.getAccountById(ratingDto.getFriendId()));
+        rating.setAccount(accountService.getLoggedAccount());
+        rating.setFriend(accountService.getAccountById(ratingDto.getFriendId()));
         return rating;
     }
 

--- a/src/test/java/com/volasoftware/tinder/services/implementations/RatingServiceImplTest.java
+++ b/src/test/java/com/volasoftware/tinder/services/implementations/RatingServiceImplTest.java
@@ -13,7 +13,6 @@ import com.volasoftware.tinder.exceptions.RatingNotValidException;
 import com.volasoftware.tinder.models.Account;
 import com.volasoftware.tinder.models.Rating;
 import com.volasoftware.tinder.repositories.RatingRepository;
-import com.volasoftware.tinder.services.contracts.AuthenticationService;
 import com.volasoftware.tinder.services.contracts.FriendService;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,7 +33,7 @@ class RatingServiceImplTest {
     private RatingRepository ratingRepository;
 
     @MockBean
-    private AuthenticationService authenticationService;
+    private AccountServiceImpl accountService;
 
     @MockBean
     private FriendService friendService;
@@ -44,7 +43,7 @@ class RatingServiceImplTest {
     @BeforeEach
     public void setUp() {
         ratingService = new RatingServiceImpl(ratingRepository, friendService,
-            authenticationService);
+            accountService);
     }
 
     @Test
@@ -68,8 +67,8 @@ class RatingServiceImplTest {
 
         when(ratingRepository.findByFriendId(ratingDto.getFriendId())).thenReturn(
             Optional.of(rating));
-        when(authenticationService.getLoggedAccount()).thenReturn(loggedAccount);
-        when(authenticationService.getAccountById(anyLong())).thenReturn(friend);
+        when(accountService.getLoggedAccount()).thenReturn(loggedAccount);
+        when(accountService.getAccountById(anyLong())).thenReturn(friend);
         rating.setRating(ratingDto.getRating());
         when(ratingRepository.save(any(Rating.class))).thenReturn(rating);
         when(friendService.getFriendInfo(ratingDto.getFriendId())).thenReturn(friendDto);


### PR DESCRIPTION
Resolved Circular Dependency in Beans: `AuthenticationController`, `AuthenticationService` and `FriendService`.

During the implementation of the task "Add friends to new users" (TIN-25), a circular dependency issue arose between `FriendService` and `AuthenticationService`. To resolve this, I've restructured the project services as follows:

Established a new `AccountService`, to which I've relocated certain `Account`-related methods previously housed in `AuthenticationService`.

With the introduction of `AccountService`, `FriendService` and `AuthenticationService` are no longer directly dependent on each other, effectively breaking the circular dependency.

In addition to these primary changes, related modifications have been made in other files to support this restructuring.